### PR TITLE
Prevent running the `wait_requests` script without AWS_PROFILE set

### DIFF
--- a/wait_requests
+++ b/wait_requests
@@ -9,6 +9,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+# Check if AWS profile is set
+if [ -z "$AWS_PROFILE" ]; then
+    echo "Error: AWS_PROFILE environment variable is not set."
+    exit 1
+fi
+
 # Get the output file from the first script argument
 output_file=$1
 


### PR DESCRIPTION
#### Description

Not setting the `AWS_PROFILE` will make for an inconspicuous error. The `AWS_PROFILE` is expected to point to LocalStack's instance if running the infrastructure on LocalStack or to AWS if deploying it to AWS.

```text
# ~/.aws/config
[profile localstack]
region=us-east-1
output=json
endpoint_url=https://localhost.localstack.cloud:4566

[profile aws]
region=us-east-1
output=json
```

```text
# ~/.aws/credentials
[localstack]
aws_access_key_id=test
aws_secret_access_key=test

[aws]
aws_access_key_id=<my-super-secret-access-key-id>
aws_secret_access_key=<my-super-secret-access-key>
```