### PR TITLE
Restrict CW datapoint time range and use v1 implementation of CW

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ The following dependencies need to be available on your machine:
 
 ## Commands
 
- * `localstack start`                         start LocalStack with the Docker executor
- * `cdk bootstrap`                            bootstrap cdk stack onto AWS/LocalStack
- * `cdk deploy`                               deploy this stack to your default AWS account/region
- * `cdk diff`                                 compare deployed stack with current state
- * `cdk synth`                                emits the synthesized CloudFormation template
- * `go test`                                  run unit tests
- * `watchman [upstream|midstream|downstream]` watch and hot-reload lambda functions
- * `wait_requests <latencies_file.json>`      wait until all requests are processed and export the latencies
+ * `localstack start` start LocalStack with the Docker executor
+ * `cdk bootstrap`                                    bootstrap cdk stack onto AWS/LocalStack
+ * `cdk deploy`                                       deploy this stack to your default AWS account/region
+ * `cdk diff`                                         compare deployed stack with current state
+ * `cdk synth`                                        emits the synthesized CloudFormation template
+ * `go test`                                          run unit tests
+ * `watchman [upstream|midstream|downstream]`         watch and hot-reload lambda functions
+ * `wait_requests <latencies_file.json>`              wait until all requests are processed and export the latencies
 
 ## Configuration
 
@@ -41,6 +41,10 @@ The following dependencies need to be available on your machine:
 On LocalStack:
 
 ```bash
+export PROVIDER_OVERRIDE_CLOUDWATCH=v1
+export LAMBDA_EVENT_SOURCE_MAPPING=v2
+localstack start -d
+
 export USE_LOCALSTACK=true
 export HOT_DEPLOY=true
 cdklocal bootstrap
@@ -88,14 +92,14 @@ arn:aws:cloudformation:us-east-1:000000000000:stack/ServerlessDataProcessingPipe
 
 ✨  Total time: 34.4s
 
-localstack@macintosh serverless-data-processing-pipeline % export API_ENDPOINT="https://tsyeuri986.execute-api.localhost.localstack.cloud:4566/prod/"
+localstack@macintosh serverless-data-processing-pipeline % export APIGW_ENDPOINT="https://tsyeuri986.execute-api.localhost.localstack.cloud:4566/prod/"
 ```
 
 Followed by a sample request:
 
 ```sh
 localstack@macintosh serverless-data-processing-pipeline % timestamp=$(awk 'BEGIN {srand(); print srand()}')
-localstack@macintosh serverless-data-processing-pipeline % curl -XPOST -H "Content-Type: application/json" $API_ENDPOINT -d "$(jq -n --arg ts "$timestamp" '{id: "1", message: "Hello World", timestamp: $ts | tonumber}')" -i
+localstack@macintosh serverless-data-processing-pipeline % curl -XPOST -H "Content-Type: application/json" $APIGW_ENDPOINT -d "$(jq -n --arg ts "$timestamp" '{id: "1", message: "Hello World", timestamp: $ts | tonumber}')" -i
 HTTP/2 200 
 content-type: application/json
 content-length: 21
@@ -108,7 +112,7 @@ server: hypercorn-h2
 ## Stress Test
 
 ```sh
-$ k6 run -e API_ENDPOINT=$API_ENDPOINT loadtest.js
+$ k6 run -e APIGW_ENDPOINT=$APIGW_ENDPOINT loadtest.js
 
 
           /\      |‾‾| /‾‾/   /‾‾/   

--- a/loadtest.js
+++ b/loadtest.js
@@ -1,10 +1,10 @@
 import http from 'k6/http';
 import { check } from 'k6';
 
-// Get the API_ENDPOINT environment variable.
-const API_ENDPOINT = __ENV.API_ENDPOINT;
-if (!API_ENDPOINT) {
-    throw new Error("Please set the API_ENDPOINT environment variable");
+// Get the APIGW_ENDPOINT environment variable.
+const APIGW_ENDPOINT = __ENV.APIGW_ENDPOINT;
+if (!APIGW_ENDPOINT) {
+    throw new Error("Please set the APIGW_ENDPOINT environment variable");
 }
 
 export let options = {
@@ -28,7 +28,7 @@ export default function () {
 
     // Send a POST request to the server.
     let response = http.post(
-        API_ENDPOINT,
+        APIGW_ENDPOINT,
         body,
         { headers: { 'Content-Type': 'application/json' } },
     );

--- a/wait_requests
+++ b/wait_requests
@@ -14,14 +14,25 @@ output_file=$1
 
 echo "Monitoring CloudWatch metrics for new datapoints..."
 
+# Check if localstack-main container is running
+if [ -z "$(docker ps -q -f name=localstack-main)" ]; then
+    echo "Error: LocalStack container is not running."
+    exit 1
+fi
+
+# Get the start time of the localstack container
+start_time=$(docker inspect -f '{{.State.StartedAt}}' localstack-main | sed 's/\.[0-9]*Z//' | xargs -I{} date -u -j -f '%Y-%m-%dT%H:%M:%S' {} +'%Y-%m-%dT%H:%M:%S')
+end_time=$(date -u +'%Y-%m-%dT%H:%M:%S')
+
 # Initial run to get the current number of datapoints
-current_datapoints=$(aws cloudwatch get-metric-statistics --namespace ServerlessDataProcessingPipeline/Latencies --metric-name Latency --start-time 2022-01-01T00:00:00 --end-time 2025-01-02T00:00:00 --period 1 --statistics SampleCount | jq '[.Datapoints[].SampleCount] | add')
+current_datapoints=$(aws cloudwatch get-metric-statistics --namespace ServerlessDataProcessingPipeline/Latencies --metric-name Latency --start-time $start_time --end-time $end_time --period 1 --statistics SampleCount | jq '[.Datapoints[].SampleCount] | add')
 
 while true; do
     sleep 5  # Wait for 5 seconds
+    end_time=$(date -u +'%Y-%m-%dT%H:%M:%S')
 
     # Get the number of datapoints again
-    new_datapoints=$(aws cloudwatch get-metric-statistics --namespace ServerlessDataProcessingPipeline/Latencies --metric-name Latency --start-time 2022-01-01T00:00:00 --end-time 2025-01-02T00:00:00 --period 1 --statistics SampleCount | jq '[.Datapoints[].SampleCount] | add')
+    new_datapoints=$(aws cloudwatch get-metric-statistics --namespace ServerlessDataProcessingPipeline/Latencies --metric-name Latency --start-time $start_time --end-time $end_time --period 1 --statistics SampleCount | jq '[.Datapoints[].SampleCount] | add')
 
     # If the number of datapoints hasn't changed, break the loop
     if [ "$new_datapoints" -eq "$current_datapoints" ]; then
@@ -36,4 +47,4 @@ done
 
 # Export the datapoints to the output file in JSON format
 echo "Exporting CloudWatch metrics to $output_file..."
-aws cloudwatch get-metric-statistics --namespace ServerlessDataProcessingPipeline/Latencies --metric-name Latency --start-time 2020-01-01T00:00:00 --end-time 2030-01-02T00:00:00 --period 1 --statistics Average | jq '[.Datapoints[].Average]' > "$output_file"
+aws cloudwatch get-metric-statistics --namespace ServerlessDataProcessingPipeline/Latencies --metric-name Latency --start-time $start_time --end-time $end_time --period 1 --statistics Average | jq '[.Datapoints[].Average]' > "$output_file"


### PR DESCRIPTION
#### Description

Using the default CW v2 provider becomes unresponsive when lots of datapoints are being retrieved. There are two issues:

1. The given timeline and the total number of datapoints is too huge, and would have been rejected by AWS nonetheless: 

```bash
AWS_PROFILE=aws aws cloudwatch get-metric-statistics --namespace ServerlessDataProcessingPipeline/Latencies --metric-name Latency --start-time 2022-01-01T00:00:00 --end-time 2025-01-02T00:00:00 --period 1 --statistics SampleCount

An error occurred (InvalidParameterCombination) when calling the GetMetricStatistics operation: You have requested up to 94780800 datapoints, which exceeds the limit of 1440. You may reduce the datapoints requested by increasing Period, or decreasing the time range.
```

This PR restricts that range to a more manageable timeframe: 24 minutes (1440 1-sec intervals).

2. It would appear that the v2 implementation runs into a lock issue with the underlying sqlite db. Therefore, the CW service "crashes" and times out.

#### Resolution

This PR reduces the necessary timeline, but keeps the same granularity (1-sec intervals). And we switch over to the previous implementation of CW that doesn't rely on sqlite, but on an in-memory setup. 